### PR TITLE
Calculations and ordering by index

### DIFF
--- a/server/dotnet/FlowerBI.Engine.Tests/IntegrationTests.cs
+++ b/server/dotnet/FlowerBI.Engine.Tests/IntegrationTests.cs
@@ -97,5 +97,87 @@ namespace FlowerBI.Engine.Tests
             record.Selected.First().Should().Be(null);
             record.Selected.Last().Should().Be(26);
         }
+
+        [Fact]
+        public void SqlServerCalculations()
+        {
+            var queryJson = new QueryJson
+            {
+                Select = new List<string> { "Vendor.VendorName" },
+                Aggregations = new List<AggregationJson>
+                {
+                    new AggregationJson
+                    {
+                        Column = "Invoice.Amount",
+                        Function = AggregationType.Sum
+                    },
+
+                    new AggregationJson
+                    {
+                        Column = "Invoice.Id",
+                        Function = AggregationType.Count
+                    }
+                },
+                Calculations = new List<CalculationJson>
+                {
+                    new() { Aggregation = 1 },
+                    new()
+                    {
+                        Operator = "+",
+                        First = new() { Aggregation = 0 },
+                        Second = new() { Value = 3 },
+                    },
+                    new()
+                    {
+                        Operator = "/",
+                        First = new() { Aggregation = 0 },
+                        Second = new() { Aggregation = 1 },
+                    }                    
+                },
+                OrderBy = new List<OrderingJson> 
+                {
+                     new OrderingJson { Type = OrderingType.Calculation, Index = 1 } 
+                },
+                Skip = 5,
+                Take = 10
+            };
+
+            var filterParams = new DictionaryFilterParameters();
+
+            var query = new Query(queryJson, Schema);
+
+            var sql = query.ToSql(new SqlServerFormatter(), filterParams, Enumerable.Empty<Filter>());
+
+            QueryGenerationTests.AssertSameSql(sql, @"            
+                with Aggregation0 as (        
+                    select
+                        [tbl00].[VendorName] Select0, 
+                        Sum([tbl01].[FancyAmount]) Value0
+                    from [Testing].[Supplier] tbl00
+                    join [Testing].[Invoice] tbl01 on [tbl01].[VendorId] = [tbl00].[Id]
+                    group by [tbl00].[VendorName]
+                ) ,
+                Aggregation1 as (        
+                    select
+                        [tbl00].[VendorName] Select0, 
+                        Count([tbl01].[Id]) Value0
+                    from [Testing].[Supplier] tbl00
+                    join [Testing].[Invoice] tbl01 on [tbl01].[VendorId] = [tbl00].[Id]
+                    group by [tbl00].[VendorName]
+                )
+                select
+                    a0.Select0,
+                    a0.Value0 Value0 ,
+                    a1.Value0 Value1 ,
+                    a1.Value0 Value2 ,
+                    a0.Value0 + 3 Value3 ,
+                    a0.Value0 / iif(a1.Value0 = 0, cast(a1.Value0 as double), 0) Value4
+                from Aggregation0 a0
+                left join Aggregation1 a1 on
+                    a1.Select0 = a0.Select0
+                order by 4 asc
+                offset 5 rows
+                fetch next 10 rows only");
+        }
     }
 }

--- a/server/dotnet/FlowerBI.Engine/JsonModels/CalculationJson.cs
+++ b/server/dotnet/FlowerBI.Engine/JsonModels/CalculationJson.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FlowerBI;
+
+public class CalculationJson
+{
+    public decimal? Value { get; set; }
+
+    public int? Aggregation { get; set; }
+
+    public CalculationJson First { get; set; }
+
+    public CalculationJson Second { get; set; }
+
+    public string Operator { get; set; }
+
+    private static readonly ISet<string> _allowedOperators 
+        = new[] { "+", "-", "*", "/" }.ToHashSet();
+
+    public string ToSql(ISqlFormatter sql)
+    {
+        if (Value != null)
+        {
+            RequireNulls(Aggregation, First, Second, Operator);
+            return $"{Value}";
+        }
+
+        if (Aggregation != null)
+        {
+            RequireNulls(Value, First, Second, Operator);
+            return $"a{Aggregation}.Value0";
+        }
+
+        if (First != null && Second != null && Operator != null)
+        {
+            RequireNulls(Aggregation, Value);
+
+            if (!_allowedOperators.Contains(Operator))
+            {
+                throw new InvalidOperationException($"Operator '{Operator}' not supported");
+            }
+
+            var second = Operator == "/" 
+                ? sql.Conditional($"{Second.ToSql(sql)} = 0", sql.CastToFloat(Second.ToSql(sql)), "0")
+                : Second.ToSql(sql);
+
+            return $"{First.ToSql(sql)} {Operator} {second}";
+        }
+
+        throw new InvalidOperationException("Calculation does not specify enough properties");
+    }
+
+    public void RequireNulls(params object[] nulls)
+    {
+        if (nulls.Any(x => x != null))
+        {
+            throw new InvalidOperationException("Calculation has too many properties in same object");
+        }
+    }
+}

--- a/server/dotnet/FlowerBI.Engine/JsonModels/OrderingJson.cs
+++ b/server/dotnet/FlowerBI.Engine/JsonModels/OrderingJson.cs
@@ -1,9 +1,20 @@
 ﻿namespace FlowerBI.Engine.JsonModels
 {
+    public enum OrderingType
+    {
+        Select,
+        Value,
+        Calculation,
+    }
+
     public class OrderingJson
     {
         public bool Descending { get; set; }
 
         public string Column { get; set; }
+
+        public OrderingType? Type { get;set; }
+        
+        public int? Index { get; set; }
     }
 }

--- a/server/dotnet/FlowerBI.Engine/JsonModels/QueryJson.cs
+++ b/server/dotnet/FlowerBI.Engine/JsonModels/QueryJson.cs
@@ -12,6 +12,8 @@ namespace FlowerBI.Engine.JsonModels
 
         public IList<OrderingJson> OrderBy { get; set; }
 
+        public IList<CalculationJson> Calculations { get; set; }
+
         public bool? Totals { get; set; }
 
         public long? Skip { get; set; }

--- a/server/dotnet/FlowerBI.Engine/QueryGeneration/ISqlFormatter.cs
+++ b/server/dotnet/FlowerBI.Engine/QueryGeneration/ISqlFormatter.cs
@@ -5,6 +5,8 @@
         string Identifier(string name);
         string EscapedIdentifierPair(string id1, string id2);
         string SkipAndTake(long skip, int take);
+        string Conditional(string predExpr, string thenExpr, string elseExpr);
+        string CastToFloat(string valueExpr);
     }
 
     public static class SqlFormatterExtensions
@@ -21,6 +23,12 @@
         public string SkipAndTake(long skip, int take) => @$"
             offset {skip} rows
             fetch next {take} rows only";
+
+        public string Conditional(string predExpr, string thenExpr, string elseExpr)
+            => $"iif({predExpr}, {thenExpr}, {elseExpr})";
+
+        public string CastToFloat(string valueExpr)
+            => $"cast({valueExpr} as double)";
     }
 
     public class SqlLiteFormatter : ISqlFormatter
@@ -28,5 +36,10 @@
         public string Identifier(string name) => $"`{name}`";
         public string EscapedIdentifierPair(string id1, string id2) => $"{id1}.{id2}";
         public string SkipAndTake(long skip, int take) => $"limit {take} offset {skip}";
+        public string Conditional(string predExpr, string thenExpr, string elseExpr)
+            => $"if({predExpr}, {thenExpr}, {elseExpr})";
+
+        public string CastToFloat(string valueExpr)
+            => $"cast({valueExpr} as real)";
     }
 }


### PR DESCRIPTION
Simple support for adding columns to the results, using arithmetic expression trees specified in JSON. They appear as extra values in the output, and can depend on the values of aggregations (but not other calculations).

Also support for specifying `order by` columns by index rather than name (which only worked for `select` columns). The index can be of a select, a value (aggregation) or calculation.

Use cases include selecting two values, then calculating the ratio of them, and then ordering by that.