### PR TITLE
Client-side support for specifying calculations/ordering

### DIFF
--- a/client/packages/flowerbi-react/src/FlowerBITable.tsx
+++ b/client/packages/flowerbi-react/src/FlowerBITable.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { QueryValues, QueryValuesRow, QueryValuesTotal, ExpandedQueryResult, QuerySelect } from "flowerbi";
+import { QueryValues, QueryValuesRow, QueryValuesTotal, ExpandedQueryResult, QuerySelect, QueryCalculations } from "flowerbi";
 
 export type ColumnDefinition = string | [string, "left" | "right"];
 
@@ -14,14 +14,14 @@ function renderCell(key: string, def: ColumnDefinition) {
     );
 }
 
-export type FlowerBITableProps<S extends QuerySelect> = {
-    data: ExpandedQueryResult<S>;
+export type FlowerBITableProps<S extends QuerySelect, C extends QueryCalculations<S>> = {
+    data: ExpandedQueryResult<S, C>;
     columns: {
-        [label: string]: (record: QueryValues<S>) => ColumnDefinition;
-    }
+        [label: string]: (record: QueryValues<S, C>) => ColumnDefinition;
+    };
 };
 
-export function FlowerBITable<S extends QuerySelect>({data, columns}: FlowerBITableProps<S>) {
+export function FlowerBITable<S extends QuerySelect, C extends QueryCalculations<S>>({ data, columns }: FlowerBITableProps<S, C>) {
     return (
         <table>
             <thead>
@@ -34,21 +34,13 @@ export function FlowerBITable<S extends QuerySelect>({data, columns}: FlowerBITa
             <tbody>
                 {data.records.map((record, i) => (
                     <tr key={JSON.stringify(record.selected) ?? i}>
-                    { 
-                        Object.keys(columns).map((column) => renderCell(
-                            column, columns[column](new QueryValuesRow(record, data.totals)))) 
-                    }
+                        {Object.keys(columns).map((column) => renderCell(column, columns[column](new QueryValuesRow<S, C>(record, data.totals))))}
                     </tr>
                 ))}
             </tbody>
             {data.totals && (
                 <tfoot>
-                    <tr>
-                    {
-                        Object.keys(columns).map((column) => renderCell(
-                            column, columns[column](new QueryValuesTotal(data.totals!))))
-                    }
-                    </tr>
+                    <tr>{Object.keys(columns).map((column) => renderCell(column, columns[column](new QueryValuesTotal<S, C>(data.totals!))))}</tr>
                 </tfoot>
             )}
         </table>

--- a/client/packages/flowerbi/src/QueryJson.ts
+++ b/client/packages/flowerbi/src/QueryJson.ts
@@ -37,13 +37,36 @@ export interface AggregationJson {
 
 /**
  * Specifies an ordering criteria: which column to sort by, and optionally
- * whether it is descending (the default is ascending). The column is
- * specified by a string of the form `table.column`.
+ * whether it is descending (the default is ascending). The column can be
+ * specified by a string of the form `table.column`, though this can only
+ * target one of the columns specified in select. More flexibly, specify
+ * a type of column (the type 'Value' refers to aggregations) and its
+ * zero-based position.
  */
-export interface OrderingJson {
-    column: string;
+export type OrderingJson = {
     descending?: boolean;
-}
+} & (
+    | {
+          column: string;
+      }
+    | {
+          type: "Select" | "Value" | "Calculation";
+          index: number;
+      }
+);
+
+/**
+ * Specifies an expression for calculating a derived value based on
+ * the values of aggregations, specified by zero-based position.
+ */
+export type CalculationJson =
+    | { value: number }
+    | { aggregation: number }
+    | {
+          first: CalculationJson;
+          operator: "+" | "-" | "*" | "/";
+          second: CalculationJson;
+      };
 
 /**
  * Specifies an entire query.
@@ -57,6 +80,10 @@ export interface QueryJson {
      * The aggregated values to fetch.
      */
     aggregations: AggregationJson[];
+    /**
+     * The calculations to perform.
+     */
+    calculations?: CalculationJson[];
     /**
      * Filters to apply. They are always combined with AND.
      */

--- a/client/packages/flowerbi/src/QueryValues.ts
+++ b/client/packages/flowerbi/src/QueryValues.ts
@@ -1,29 +1,29 @@
-import { 
-    QuerySelect, 
-    ExpandedQueryRecord, 
-    AggregateValuesOnly, 
-    AggregatePropsOnly, 
-    ExpandedQueryRecordWithOptionalColumns 
+import {
+    QuerySelect,
+    ExpandedQueryRecord,
+    AggregateValuesOnly,
+    AggregatePropsOnly,
+    ExpandedQueryRecordWithOptionalColumns,
+    QueryCalculations,
+    CalculationValues,
 } from "./queryModel";
 
 /**
  * An abstract interface representing either a row from a dataset or
- * the {@link ExpandedQueryResult.totals} row, so that generic code can 
+ * the {@link ExpandedQueryResult.totals} row, so that generic code can
  * format either of them in a consistent way.
  */
-export interface QueryValues<S extends QuerySelect> {
+export interface QueryValues<S extends QuerySelect, C extends QueryCalculations<S>> {
     /**
      * The plain values of columns, which may be `undefined` if this
      * refers to the {@link ExpandedQueryResult.totals} record.
      */
-    values: ExpandedQueryRecordWithOptionalColumns<S>;
+    values: ExpandedQueryRecordWithOptionalColumns<S, C>;
     percentage<K extends AggregatePropsOnly<S>>(key: K): number;
 }
 
-export class QueryValuesRow<S extends QuerySelect> implements QueryValues<S> {
-    constructor(
-        public readonly values: ExpandedQueryRecord<S>, 
-        public readonly totals: AggregateValuesOnly<S> | undefined) {}
+export class QueryValuesRow<S extends QuerySelect, C extends QueryCalculations<S>> implements QueryValues<S, C> {
+    constructor(public readonly values: ExpandedQueryRecord<S, C>, public readonly totals: (AggregateValuesOnly<S> & CalculationValues<C>) | undefined) {}
 
     percentage<K extends AggregatePropsOnly<S>>(key: K) {
         if (!this.totals) return 0;
@@ -35,11 +35,11 @@ export class QueryValuesRow<S extends QuerySelect> implements QueryValues<S> {
     }
 }
 
-export class QueryValuesTotal<S extends QuerySelect> implements QueryValues<S> {
-    public readonly values: ExpandedQueryRecordWithOptionalColumns<S>;
+export class QueryValuesTotal<S extends QuerySelect, C extends QueryCalculations<S>> implements QueryValues<S, C> {
+    public readonly values: ExpandedQueryRecordWithOptionalColumns<S, C>;
 
-    constructor(totals: AggregateValuesOnly<S>) {
-        this.values = totals as ExpandedQueryRecordWithOptionalColumns<S>;
+    constructor(totals: AggregateValuesOnly<S> & CalculationValues<C>) {
+        this.values = totals as ExpandedQueryRecordWithOptionalColumns<S, C>;
     }
 
     percentage() {

--- a/client/packages/flowerbi/src/executeQuery.test.ts
+++ b/client/packages/flowerbi/src/executeQuery.test.ts
@@ -1,5 +1,6 @@
-import { jsonifyQuery } from "./executeQuery";
+import { expandQueryResult, jsonifyQuery, QueryResultJson } from "./executeQuery";
 import { QueryColumn } from "./QueryColumn";
+import { Query, QueryCalculations, QuerySelect } from "./queryModel";
 
 export const Customer = {
     Id: new QueryColumn<number>("Customer.Id"),
@@ -8,22 +9,28 @@ export const Customer = {
 
 export const Bug = {
     Id: new QueryColumn<number>("Bug.Id"),
-    CustomerId: new QueryColumn<number>("Bug.CustomerId"),    
+    CustomerId: new QueryColumn<number>("Bug.CustomerId"),
+    Fixed: new QueryColumn<boolean>("Bug.Fixed"),
 };
 
-test("jsonifies mixed columns", () => {    
-    expect(jsonifyQuery({
-        select: {
-            customer: Customer.CustomerName,
-            bugCount: Bug.Id.count()
-        }
-    })).toStrictEqual({
+test("jsonifies mixed columns", () => {
+    expect(
+        jsonifyQuery({
+            select: {
+                customer: Customer.CustomerName,
+                bugCount: Bug.Id.count(),
+            },
+        })
+    ).toStrictEqual({
         select: ["Customer.CustomerName"],
-        aggregations: [{
-            column: "Bug.Id",
-            function: "Count",
-            filters: undefined
-        }],
+        aggregations: [
+            {
+                column: "Bug.Id",
+                function: "Count",
+                filters: undefined,
+            },
+        ],
+        calculations: undefined,
         filters: [],
         orderBy: [],
         skip: 0,
@@ -34,14 +41,17 @@ test("jsonifies mixed columns", () => {
     });
 });
 
-test("jsonifies select", () => {    
-    expect(jsonifyQuery({
-        select: {
-            customer: Customer.CustomerName,
-        }
-    })).toStrictEqual({
+test("jsonifies select", () => {
+    expect(
+        jsonifyQuery({
+            select: {
+                customer: Customer.CustomerName,
+            },
+        })
+    ).toStrictEqual({
         select: ["Customer.CustomerName"],
         aggregations: [],
+        calculations: undefined,
         filters: [],
         orderBy: [],
         skip: 0,
@@ -53,16 +63,19 @@ test("jsonifies select", () => {
 });
 
 test("jsonifies params", () => {
-    expect(jsonifyQuery({
-        select: {},
-        skip: 3,
-        take: 42,
-        totals: true,
-        allowDuplicates: true,
-        comment: "a comment",
-    })).toStrictEqual({
+    expect(
+        jsonifyQuery({
+            select: {},
+            skip: 3,
+            take: 42,
+            totals: true,
+            allowDuplicates: true,
+            comment: "a comment",
+        })
+    ).toStrictEqual({
         select: [],
         aggregations: [],
+        calculations: undefined,
         filters: [],
         orderBy: [],
         skip: 3,
@@ -74,32 +87,36 @@ test("jsonifies params", () => {
 });
 
 test("jsonifies filters", () => {
-    expect(jsonifyQuery({
-        select: {
-            bugCount: Bug.Id.count([
-                Customer.CustomerName.lessThan("z")
-            ])
-        },
-        filters: [
-            Customer.CustomerName.greaterThan("a")
-        ]
-        
-    })).toStrictEqual({
+    expect(
+        jsonifyQuery({
+            select: {
+                bugCount: Bug.Id.count([Customer.CustomerName.lessThan("z")]),
+            },
+            filters: [Customer.CustomerName.greaterThan("a")],
+        })
+    ).toStrictEqual({
         select: [],
-        aggregations: [{
-            column: "Bug.Id",
-            function: "Count",
-            filters: [{
+        aggregations: [
+            {
+                column: "Bug.Id",
+                function: "Count",
+                filters: [
+                    {
+                        column: "Customer.CustomerName",
+                        operator: "<",
+                        value: "z",
+                    },
+                ],
+            },
+        ],
+        calculations: undefined,
+        filters: [
+            {
                 column: "Customer.CustomerName",
-                operator: "<",
-                value: "z",
-            }]
-        }],
-        filters: [{
-            column: "Customer.CustomerName",
-            operator: ">",
-            value: "a",
-        }],
+                operator: ">",
+                value: "a",
+            },
+        ],
         orderBy: [],
         skip: 0,
         take: 100,
@@ -109,24 +126,208 @@ test("jsonifies filters", () => {
     });
 });
 
-test("jsonifies orderBy", () => {    
-    expect(jsonifyQuery({
-        select: {},
-        orderBy: [
-            Customer.CustomerName.descending()
-        ]
-    })).toStrictEqual({
+test("jsonifies orderBy", () => {
+    expect(
+        jsonifyQuery({
+            select: {},
+            orderBy: [Customer.CustomerName.descending()],
+        })
+    ).toStrictEqual({
         select: [],
         aggregations: [],
+        calculations: undefined,
         filters: [],
-        orderBy: [{
-            column: "Customer.CustomerName",
-            descending: true,
-        }],
+        orderBy: [
+            {
+                column: "Customer.CustomerName",
+                descending: true,
+            },
+        ],
         skip: 0,
         take: 100,
         totals: false,
         allowDuplicates: undefined,
         comment: undefined,
+    });
+});
+
+test("jsonifies calculations and ordering by keys", () => {
+    expect(
+        jsonifyQuery({
+            select: {
+                customer: Customer.CustomerName,
+                bugCount: Bug.Id.count(),
+                bugsFixed: Bug.Id.count([Bug.Fixed.equalTo(true)]),
+            },
+            calculations: {
+                successRate: [100, "*", ["bugsFixed", "/", "bugCount"]],
+                failureRate: [100, "-", [100, "*", ["bugsFixed", "/", "bugCount"]]],
+            },
+            orderBy: [
+                { select: "customer" },
+                { select: "bugsFixed", descending: true },
+                { calculation: "successRate" },
+                { calculation: "failureRate", descending: true },
+            ],
+        })
+    ).toStrictEqual({
+        select: ["Customer.CustomerName"],
+        aggregations: [
+            {
+                column: "Bug.Id",
+                function: "Count",
+                filters: undefined,
+            },
+            {
+                column: "Bug.Id",
+                function: "Count",
+                filters: [
+                    {
+                        column: "Bug.Fixed",
+                        operator: "=",
+                        value: true,
+                    },
+                ],
+            },
+        ],
+        calculations: [
+            {
+                first: { value: 100 },
+                operator: "*",
+                second: {
+                    first: { aggregation: 1 },
+                    operator: "/",
+                    second: { aggregation: 0 },
+                },
+            },
+            {
+                first: { value: 100 },
+                operator: "-",
+                second: {
+                    first: { value: 100 },
+                    operator: "*",
+                    second: {
+                        first: { aggregation: 1 },
+                        operator: "/",
+                        second: { aggregation: 0 },
+                    },
+                },
+            },
+        ],
+        filters: [],
+        orderBy: [
+            { type: "Select", index: 0, descending: undefined },
+            { type: "Value", index: 1, descending: true },
+            { type: "Calculation", index: 0, descending: undefined },
+            { type: "Calculation", index: 1, descending: true },
+        ],
+        skip: 0,
+        take: 100,
+        totals: false,
+        allowDuplicates: undefined,
+        comment: undefined,
+    });
+});
+
+test("passes through JSON orderBy", () => {
+    expect(
+        jsonifyQuery({
+            select: {},
+            orderBy: [Customer.CustomerName.descending()],
+        })
+    ).toStrictEqual({
+        select: [],
+        aggregations: [],
+        calculations: undefined,
+        filters: [],
+        orderBy: [
+            {
+                column: "Customer.CustomerName",
+                descending: true,
+            },
+        ],
+        skip: 0,
+        take: 100,
+        totals: false,
+        allowDuplicates: undefined,
+        comment: undefined,
+    });
+});
+
+function formatResultsFromQuery<S extends QuerySelect, C extends QueryCalculations<S>>(query: Query<S, C>, result: QueryResultJson) {
+    return expandQueryResult<S, C>(query.select, result, query.calculations);
+}
+
+test("generates typed results", () => {
+    const result = formatResultsFromQuery(
+        {
+            select: {
+                customer: Customer.CustomerName,
+                bugCount: Bug.Id.count(),
+                bugsFixed: Bug.Id.count([Bug.Fixed.equalTo(true)]),
+            },
+            calculations: {
+                successRate: [100, "*", ["bugsFixed", "/", "bugCount"]],
+                failureRate: [100, "-", [100, "*", ["bugsFixed", "/", "bugCount"]]],
+            },
+            orderBy: [
+                { select: "customer" },
+                { select: "bugsFixed", descending: true },
+                { calculation: "successRate" },
+                { calculation: "failureRate", descending: true },
+            ],
+        },
+        {
+            records: [
+                {
+                    selected: ["woolworths"],
+                    aggregated: [3, 1, 33.33, 66.67],
+                },
+            ],
+        }
+    );
+
+    expect(result).toStrictEqual({
+        records: [{ customer: "woolworths", bugCount: 3, bugsFixed: 1, successRate: 33.33, failureRate: 66.67 }],
+        totals: undefined,
+    });
+});
+
+test("generates typed results with totals", () => {
+    const result = formatResultsFromQuery(
+        {
+            select: {
+                customer: Customer.CustomerName,
+                bugCount: Bug.Id.count(),
+                bugsFixed: Bug.Id.count([Bug.Fixed.equalTo(true)]),
+            },
+            calculations: {
+                successRate: [100, "*", ["bugsFixed", "/", "bugCount"]],
+                failureRate: [100, "-", [100, "*", ["bugsFixed", "/", "bugCount"]]],
+            },
+            orderBy: [
+                { select: "customer" },
+                { select: "bugsFixed", descending: true },
+                { calculation: "successRate" },
+                { calculation: "failureRate", descending: true },
+            ],
+        },
+        {
+            records: [
+                {
+                    selected: ["woolworths"],
+                    aggregated: [3, 1, 33.33, 66.67],
+                },
+            ],
+            totals: {
+                selected: [""],
+                aggregated: [4, 2, 50, 50],
+            },
+        }
+    );
+
+    expect(result).toStrictEqual({
+        records: [{ customer: "woolworths", bugCount: 3, bugsFixed: 1, successRate: 33.33, failureRate: 66.67 }],
+        totals: { bugCount: 4, bugsFixed: 2, successRate: 50, failureRate: 50 },
     });
 });

--- a/client/packages/flowerbi/src/executeQuery.ts
+++ b/client/packages/flowerbi/src/executeQuery.ts
@@ -1,11 +1,24 @@
-import { Query, QuerySelect, ExpandedQueryRecord, AggregateValuesOnly, getAggregatePropsOnly, getColumnPropsOnly } from "./queryModel";
-import { QueryJson, AggregationJson } from "./QueryJson";
+import {
+    Query,
+    QuerySelect,
+    ExpandedQueryRecord,
+    AggregateValuesOnly,
+    getAggregatePropsOnly,
+    getColumnPropsOnly,
+    Calculation,
+    AggregatePropsOnly,
+    QueryCalculations,
+    Ordering,
+    CalculationValues,
+} from "./queryModel";
+import { QueryJson, AggregationJson, CalculationJson, OrderingJson } from "./QueryJson";
 import { QueryColumn } from "./QueryColumn";
+import { keysOf } from "./arrayHelpers";
 
 /**
  * The allowed data types for plain columns.
  */
-export type QuerySelectValue = number|string|Date|boolean;
+export type QuerySelectValue = number | string | Date | boolean;
 
 /**
  * The JSON format of a record returned from the API when executing a query.
@@ -22,7 +35,7 @@ export interface QueryRecordJson {
 }
 
 /**
- * The JSON format of the whole payload returned from the API when 
+ * The JSON format of the whole payload returned from the API when
  * executing a query.
  */
 export interface QueryResultJson {
@@ -47,24 +60,91 @@ export interface QueryResultJson {
  */
 export type QueryFetch = (queryJson: QueryJson) => Promise<QueryResultJson>;
 
+function jsonifyCalculation<S extends QuerySelect>(calculation: Calculation<S>, props: AggregatePropsOnly<S>[]): CalculationJson {
+    if (typeof calculation === "string") {
+        const aggregation = props.indexOf(calculation);
+        if (aggregation === -1) {
+            throw new Error(`Not a valid aggregation name: ${calculation}`);
+        }
+        return { aggregation };
+    }
+    if (typeof calculation === "number") {
+        return {
+            value: calculation,
+        };
+    }
+    if (calculation instanceof Array) {
+        return {
+            first: jsonifyCalculation(calculation[0], props),
+            operator: calculation[1],
+            second: jsonifyCalculation(calculation[2], props),
+        };
+    }
+    throw new Error("Invalid calculation");
+}
+
+function jsonifyOrdering<S extends QuerySelect, C extends QueryCalculations<S>>(
+    ordering: OrderingJson | Ordering<S, C>,
+    selects: string[],
+    values: string[],
+    calculations: string[]
+): OrderingJson {
+    if ("select" in ordering) {
+        let index = selects.indexOf(ordering.select as string);
+        if (index !== -1) {
+            return {
+                type: "Select",
+                index,
+                descending: ordering.descending,
+            };
+        }
+        index = values.indexOf(ordering.select as string);
+        if (index !== -1) {
+            return {
+                type: "Value",
+                index,
+                descending: ordering.descending,
+            };
+        }
+        throw new Error(`Invalid ordering select key: ${String(ordering.select)}`);
+    }
+    if ("calculation" in ordering) {
+        let index = calculations.indexOf(ordering.calculation as string);
+        if (index !== -1) {
+            return {
+                type: "Calculation",
+                index,
+                descending: ordering.descending,
+            };
+        }
+        throw new Error(`Invalid ordering calculation key: ${String(ordering.calculation)}`);
+    }
+    return ordering;
+}
+
 /**
  * Converts a statically-typed {@link Query} into the {@link QueryJson}
  * format, ready to be sent to your API.
- * @param query 
+ * @param query
  */
-export function jsonifyQuery<S extends QuerySelect>(query: Query<S>): QueryJson {
-    const { select, filters, orderBy, totals, take, skip, comment, allowDuplicates } = query;
+export function jsonifyQuery<S extends QuerySelect, C extends QueryCalculations<S>>(query: Query<S, C>): QueryJson {
+    const { select, filters, calculations, orderBy, totals, take, skip, comment, allowDuplicates } = query;
 
-    return {        
-        select: getColumnPropsOnly(select).map(key => (select[key] as QueryColumn<never>).name),
-        aggregations: getAggregatePropsOnly(select).map(key => select[key] as AggregationJson),
+    const columnProps = getColumnPropsOnly(select);
+    const aggregationProps = getAggregatePropsOnly(select);
+    const calculationProps = calculations ? keysOf(calculations) : [];
+
+    return {
+        select: columnProps.map((key) => (select[key] as QueryColumn<never>).name),
+        aggregations: aggregationProps.map((key) => select[key] as AggregationJson),
+        calculations: calculations ? calculationProps.map((key) => jsonifyCalculation(calculations[key] as Calculation<S>, aggregationProps)) : undefined,
         filters: filters ?? [],
-        orderBy: orderBy ?? [],
+        orderBy: orderBy?.map((o) => jsonifyOrdering(o, columnProps as string[], aggregationProps as string[], calculationProps as string[])) ?? [],
         totals: totals ?? false,
         skip: skip ?? 0,
         take: take ?? 100,
         comment,
-        allowDuplicates
+        allowDuplicates,
     };
 }
 
@@ -75,15 +155,20 @@ export function jsonifyQuery<S extends QuerySelect>(query: Query<S>): QueryJson 
  * @param select The {@link Query.select} property from the query.
  * @param record The record returned from your API.
  */
-export function expandQueryRecord<S extends QuerySelect>(
+export function expandQueryRecord<S extends QuerySelect, C extends QueryCalculations<S>>(
     select: S,
-    record: QueryRecordJson
-): ExpandedQueryRecord<S> {
-    
+    record: QueryRecordJson,
+    calcs?: C
+): ExpandedQueryRecord<S, C> {
     const result: any = {};
 
     let n = 0;
     for (const key of getAggregatePropsOnly(select)) {
+        result[key] = record.aggregated[n++];
+    }
+
+    const calculationProps = calcs ? keysOf(calcs) : [];
+    for (const key of calculationProps) {
         result[key] = record.aggregated[n++];
     }
 
@@ -96,22 +181,27 @@ export function expandQueryRecord<S extends QuerySelect>(
 }
 
 /**
- * Converts the `QueryRecordJson` from the `totals` record into a strongly-typed 
+ * Converts the `QueryRecordJson` from the `totals` record into a strongly-typed
  * record named properties for the aggregated values only, using the
  * {@link Query.select} from the query to perform the necessary mapping.
- * 
+ *
  * @param select The {@link Query.select} property from the query.
  * @param record The {@link QueryResultJson.totals} record returned from your API.
  */
-export function getAggregateValuesOnly<S extends QuerySelect>(
+export function getAggregateValuesOnly<S extends QuerySelect, C extends QueryCalculations<S>>(
     select: S,
-    record: QueryRecordJson
-): AggregateValuesOnly<S> {
-
+    record: QueryRecordJson,
+    calcs?: C
+): AggregateValuesOnly<S> & CalculationValues<C> {
     const result: any = {};
 
     let n = 0;
     for (const key of getAggregatePropsOnly(select)) {
+        result[key] = record.aggregated[n++];
+    }
+
+    const calculationProps = calcs ? keysOf(calcs) : [];
+    for (const key of calculationProps) {
         result[key] = record.aggregated[n++];
     }
 
@@ -121,19 +211,19 @@ export function getAggregateValuesOnly<S extends QuerySelect>(
 /**
  * The statically-typed result of a {@link Query}.
  */
-export interface ExpandedQueryResult<S extends QuerySelect> {
+export interface ExpandedQueryResult<S extends QuerySelect, C extends QueryCalculations<S>> {
     /**
      * The set of records returned, each having named properties
      * corresponding to the plain and aggregated columns selected
      * in the query.
      */
-    records: ExpandedQueryRecord<S>[];
+    records: ExpandedQueryRecord<S, C>[];
     /**
      * Optional extra record, only available if {@link QueryJson.totals}
      * was specified as `true` in the query, containing the aggregation
      * totals.
      */
-    totals?: AggregateValuesOnly<S>;
+    totals?: AggregateValuesOnly<S> & CalculationValues<C>;
 }
 
 /**
@@ -142,13 +232,13 @@ export interface ExpandedQueryResult<S extends QuerySelect> {
  * @param select The {@link Query.select} property from the query.
  * @param result The response payload from the API call.
  */
-export function expandQueryResult<S extends QuerySelect>(
+export function expandQueryResult<S extends QuerySelect, C extends QueryCalculations<S>>(
     select: S,
-    result: QueryResultJson
-): ExpandedQueryResult<S> {
-
+    result: QueryResultJson,
+    calcs?: C
+): ExpandedQueryResult<S, C> {
     return {
-        records: result.records.map(r => expandQueryRecord(select, r)),
-        totals: result.totals && getAggregateValuesOnly(select, result.totals)
+        records: result.records.map((r) => expandQueryRecord(select, r, calcs)),
+        totals: result.totals && getAggregateValuesOnly(select, result.totals, calcs),
     };
 }

--- a/client/packages/flowerbi/src/queryModel.ts
+++ b/client/packages/flowerbi/src/queryModel.ts
@@ -3,7 +3,7 @@ import { QueryColumn } from "./QueryColumn";
 import { AggregationJson, FilterJson, OrderingJson } from "./QueryJson";
 
 /**
- * Defines the kinds of member that can appear in the `select` object of a query. 
+ * Defines the kinds of member that can appear in the `select` object of a query.
  * Queries can select plain columns, or aggregation functions on columns.
  */
 export type SelectMember = QueryColumn<any> | AggregationJson;
@@ -21,19 +21,23 @@ export type QueryColumnType<T> = T extends QueryColumn<infer C> ? C : never;
 /**
  * Defines the shape of a record returned from a query, based on its `select` object.
  * Each selected property appears as a property in the record with the same name. For
- * plain columns the data type depends on the column definition, but for aggregates
- * the data type is always `number`.
+ * plain columns the data type depends on the column definition, but for aggregations
+ * and calculations the data type is always `number`.
  */
-export type ExpandedQueryRecord<S extends QuerySelect> = { 
+export type ExpandedQueryRecord<S extends QuerySelect, C extends QueryCalculations<S>> = {
     [P in keyof S]: S[P] extends QueryColumn<any> ? QueryColumnType<S[P]> : number;
+} & {
+    [P in keyof C]: number;
 };
 
 /**
  * Similar to {@link ExpandedQueryRecord} but the plain columns are optional, so they
- * may be `undefined`. Aggregations are not optional.
+ * may be `undefined`. Aggregations/calculations are not optional.
  */
-export type ExpandedQueryRecordWithOptionalColumns<S extends QuerySelect> = { 
-    [P in keyof S]: S[P] extends QueryColumn<any> ? (QueryColumnType<S[P]> | undefined) : number;
+export type ExpandedQueryRecordWithOptionalColumns<S extends QuerySelect, C extends QueryCalculations<S>> = {
+    [P in keyof S]: S[P] extends QueryColumn<any> ? QueryColumnType<S[P]> | undefined : number;
+} & {
+    [P in keyof C]: number;
 };
 
 /**
@@ -50,30 +54,34 @@ export type AggregatePropsOnlyHelper<T extends QuerySelect> = {
 export type AggregatePropsOnly<T extends QuerySelect> = AggregatePropsOnlyHelper<T>[keyof AggregatePropsOnlyHelper<T>];
 
 /**
- * Returns the names of properties in a query that refer to aggregated columns. 
+ * Returns the names of properties in a query that refer to aggregated columns.
  * The result is an array of strings, but type-constrained to string literal types:
- * 
+ *
  * ```ts
- * getAggregatePropsOnly({ 
+ * getAggregatePropsOnly({
  *    customer: Customer.Name,
  *    spend: Invoice.Amount.sum()
  * }) // ["spend"]
  * ```
- * 
+ *
  * @param select the `select` object from a query
  */
 export function getAggregatePropsOnly<T extends QuerySelect>(select: T) {
-    const keys = keysOf(select).filter(x => !(select[x] instanceof QueryColumn))
+    const keys = keysOf(select).filter((x) => !(select[x] instanceof QueryColumn));
     return keys as AggregatePropsOnly<T>[];
 }
 
 /**
- * An object that contains a subset of the the named properties from a query's 
+ * An object that contains a subset of the the named properties from a query's
  * `select` object, those that refer to aggregated values (hence all are of
  * type `number`.)
  */
 export type AggregateValuesOnly<T extends QuerySelect> = {
     [K in AggregatePropsOnly<T>]: number;
+};
+
+export type CalculationValues<C extends QueryCalculations<any>> = {
+    [K in keyof C]: number;
 };
 
 /**
@@ -92,18 +100,18 @@ export type ColumnPropsOnly<T extends QuerySelect> = ColumnPropsOnlyHelper<T>[ke
 /**
  * Returns the names of properties in a query that refer to plain columns. The
  * result is an array of strings, but type-constrained to string literal types:
- * 
+ *
  * ```ts
- * getColumnPropsOnly({ 
+ * getColumnPropsOnly({
  *    customer: Customer.Name,
- *    spend: Invoice.Amount.sum() 
+ *    spend: Invoice.Amount.sum()
  * }) // ["customer"]
  * ```
- * 
+ *
  * @param select the `select` object from a query
  */
 export function getColumnPropsOnly<T extends QuerySelect>(select: T) {
-    const keys = keysOf(select).filter(x => select[x] instanceof QueryColumn)
+    const keys = keysOf(select).filter((x) => select[x] instanceof QueryColumn);
     return keys as ColumnPropsOnly<T>[];
 }
 
@@ -114,37 +122,54 @@ export function getColumnPropsOnly<T extends QuerySelect>(select: T) {
  */
 export function getColumnsOnly(select: QuerySelect) {
     return keysOf(select)
-        .map(k => select[k])
-        .filter(x => x instanceof QueryColumn)
-        .map(x => (x as QueryColumn<any>));
+        .map((k) => select[k])
+        .filter((x) => x instanceof QueryColumn)
+        .map((x) => x as QueryColumn<any>);
 }
 
+export type Calculation<S extends QuerySelect> = number | AggregatePropsOnly<S> | [Calculation<S>, "+" | "-" | "*" | "/", Calculation<S>];
+
 /**
- * Strongly-typed query definition: use {@link jsonifyQuery} to convert to the JSON format 
+ * The `select` object of a query has named properties of type {@link SelectMember}.
+ */
+export type QueryCalculations<S extends QuerySelect> = Record<string, Calculation<S>>;
+
+export type Ordering<S extends QuerySelect, C extends QueryCalculations<S>> = { descending?: boolean } & (
+    | {
+          select: keyof S;
+      }
+    | {
+          calculation: keyof C;
+      }
+);
+
+/**
+ * Strongly-typed query definition: use {@link jsonifyQuery} to convert to the JSON format
  * and {@link expandQueryResult} to generate corresponding output records.
  */
-export interface Query<S extends QuerySelect> {
+export interface Query<S extends QuerySelect, C extends QueryCalculations<S>> {
     select: S;
     filters?: FilterJson[];
+    calculations?: C;
     /**
      * Ordering criteria to apply.
      */
-    orderBy?: OrderingJson[];
+    orderBy?: (OrderingJson | Ordering<S, C>)[];
     /**
-     * Specifies whether to return a `totals` property containing the 
+     * Specifies whether to return a `totals` property containing the
      * aggregation values across the whole dataset, e.g. if the `select`
      * object is:
-     * 
+     *
      * ```ts
-     * { 
+     * {
      *    customer: Customer.Name,
      *    spend: Invoice.Amount.sum()
      * }
      * ```
-     * 
+     *
      * the returned `records` will have properties `customer` and `spend`,
-     * one per customer. Specify `totals: true` to also get a `totals` object 
-     * with only a `spend` property, containing the total spend across all 
+     * one per customer. Specify `totals: true` to also get a `totals` object
+     * with only a `spend` property, containing the total spend across all
      * customers.
      */
     totals?: boolean;
@@ -157,10 +182,10 @@ export interface Query<S extends QuerySelect> {
      */
     take?: number;
     /**
-     * A string to insert in a comment at the start of the generated SQL. 
-     * 
-     * This will be aggressively processed to remove the danger of injection 
-     * attacks, so anything other than alpha, numeric, new line or CR 
+     * A string to insert in a comment at the start of the generated SQL.
+     *
+     * This will be aggressively processed to remove the danger of injection
+     * attacks, so anything other than alpha, numeric, new line or CR
      * characters will be replaced with space.
      */
     comment?: string;


### PR DESCRIPTION
A strongly typed query can now specify calculations:

```ts
calculations: {
    successRate: [100, "*", ["bugsFixed", "/", "bugCount"]],
}
```

It's like a simple DSL where the nodes can be one of these patterns:

- a number, becomes a constant in the calculation
- a string that must be the key of an aggregation in the `select` object in this query
- `[x, "+", y]` i.e. a three element tuple where x and y are any nodes of these types, and the operator string in the middle must be one of `"+" |  "-" | "*" | "/"`

All type checked, so you get auto-completion when you type an aggregation key.

Similarly, there is a new way to specify orderings in `orderBy`:

```ts
orderBy: [
    { select: "bugsFixed", descending: true },
    { calculation: "successRate" },
]
```

Only one of `select` and `calculation` can be specified. If `select`, the value must be any key from the `select` object. If `calculation`, the value must be any key of the `calculation` object. Again, this is strongly typed.