### PR TITLE
Potential fix for join ordering

### DIFF
--- a/server/dotnet/FlowerBI.Engine/QueryGeneration/Joins.cs
+++ b/server/dotnet/FlowerBI.Engine/QueryGeneration/Joins.cs
@@ -164,21 +164,27 @@ namespace FlowerBI
                 throw new InvalidOperationException($"Could not connect tables: {string.Join(",", needed)}");
             }
             
-            for (var t = 0; t < reachable.Count; t++)
+            for (var repeat = true; repeat;)
             {
-                // No need to try removing a table if we already know it's directly needed
-                if (needed.Contains(reachable[t])) continue;
+                repeat = false;
 
-                // Try removing table t
-                var without = reachable.ToList();
-                without.RemoveAt(t);
-
-                var reducedTables = new TableSubset(without, referrers, JoinLabels);                
-                if (CanReachAllNeeded(reducedTables.GetReachableTables(root)))
+                foreach (var candidateForRemoval in reachable)
                 {
-                    tables = reducedTables;
-                    reachable = without;
-                    t--;
+                    // No need to try removing a table if we already know it's directly needed
+                    if (needed.Contains(candidateForRemoval)) continue;
+
+                    // Try removing table t
+                    var without = reachable.Where(x => x != candidateForRemoval).ToList();
+
+                    var reducedTables = new TableSubset(without, referrers, JoinLabels);     
+                    var reducedReachable = reducedTables.GetReachableTables(root);
+                    if (CanReachAllNeeded(reducedReachable))
+                    {
+                        tables = reducedTables;
+                        reachable = reducedReachable;
+                        repeat = true;
+                        break;
+                    }
                 }
             }
 


### PR DESCRIPTION
When tables are eliminated from the join set, this can mean that the remaining tables need to be re-sequenced to allow a list of `join T on blah` lines to be constructed such that each join definitely has what it needs to refer to in the lines above.

The sequencing happens automatically due to the way we discover the implicitly required tables in `GetReachableTables` by searching out from one of the explicitly required tables, so we visit them in an order that is suitable for declaring the joins. So the result of that method is ready to use.

But in the old loop, it just edited the original `reachable` list instead of taking the new result of `GetReachableTables`. So tables needed to make the join sequence work were potentially disappearing. So instead it needs to take the new result of that method and try again.