### PR TITLE
Allow full joins, and handle nulls in calculations

### DIFF
--- a/client/packages/flowerbi/src/queryModel.ts
+++ b/client/packages/flowerbi/src/queryModel.ts
@@ -127,7 +127,7 @@ export function getColumnsOnly(select: QuerySelect) {
         .map((x) => x as QueryColumn<any>);
 }
 
-export type Calculation<S extends QuerySelect> = number | AggregatePropsOnly<S> | [Calculation<S>, "+" | "-" | "*" | "/", Calculation<S>];
+export type Calculation<S extends QuerySelect> = number | AggregatePropsOnly<S> | [Calculation<S>, "+" | "-" | "*" | "/" | "??", Calculation<S>];
 
 /**
  * The `select` object of a query has named properties of type {@link SelectMember}.

--- a/server/dotnet/FlowerBI.Engine.Tests/IntegrationTests.cs
+++ b/server/dotnet/FlowerBI.Engine.Tests/IntegrationTests.cs
@@ -166,12 +166,14 @@ namespace FlowerBI.Engine.Tests
                     group by [tbl00].[VendorName]
                 )
                 select
-                    a0.Select0,
-                    a0.Value0 Value0 ,
-                    a1.Value0 Value1 ,
-                    a1.Value0 Value2 ,
-                    (a0.Value0 + 3) Value3 , 
-                    iif(a1.Value0 = 0, 0, a0.Value0 / cast(a1.Value0 as float)) Value4
+                    a0.Select0, 
+                    a0.Value0 Value0 , 
+                    a1.Value0 Value1 , 
+                    a1.Value0 Value2 , 
+                    (iif(a0.Value0 is null, 0, a0.Value0) + iif(3 is null, 0, 3)) Value3 , 
+                    iif(iif(a1.Value0 is null, 0, a1.Value0) = 0, 0, 
+                        iif(a0.Value0 is null, 0, a0.Value0) / 
+                        cast(iif(a1.Value0 is null, 0, a1.Value0) as float)) Value4 
                 from Aggregation0 a0
                 left join Aggregation1 a1 on
                     a1.Select0 = a0.Select0

--- a/server/dotnet/FlowerBI.Engine.Tests/IntegrationTests.cs
+++ b/server/dotnet/FlowerBI.Engine.Tests/IntegrationTests.cs
@@ -165,15 +165,12 @@ namespace FlowerBI.Engine.Tests
                     join [Testing].[Invoice] tbl01 on [tbl01].[VendorId] = [tbl00].[Id]
                     group by [tbl00].[VendorName]
                 )
-                select
-                    a0.Select0, 
+                select a0.Select0, 
                     a0.Value0 Value0 , 
                     a1.Value0 Value1 , 
                     a1.Value0 Value2 , 
-                    (iif(a0.Value0 is null, 0, a0.Value0) + iif(3 is null, 0, 3)) Value3 , 
-                    iif(iif(a1.Value0 is null, 0, a1.Value0) = 0, 0, 
-                        iif(a0.Value0 is null, 0, a0.Value0) / 
-                        cast(iif(a1.Value0 is null, 0, a1.Value0) as float)) Value4 
+                    (a0.Value0 + 3) Value3 , 
+                    iif(a1.Value0 = 0, 0, a0.Value0 / cast(a1.Value0 as float)) Value4 
                 from Aggregation0 a0
                 left join Aggregation1 a1 on
                     a1.Select0 = a0.Select0

--- a/server/dotnet/FlowerBI.Engine.Tests/QueryGenerationTests.cs
+++ b/server/dotnet/FlowerBI.Engine.Tests/QueryGenerationTests.cs
@@ -1075,15 +1075,20 @@ namespace FlowerBI.Engine.Tests
                 {
                     new() { Aggregation = 1 },
                     new()
-                    {
+                    {                        
+                        First = new() 
+                        {                             
+                            First = new() { Aggregation = 0 }, 
+                            Operator = "??", 
+                            Second = new() { Value = 42 } 
+                        },
                         Operator = "+",
-                        First = new() { Aggregation = 0 },
                         Second = new() { Value = 3 },
                     },
                     new()
-                    {
-                        Operator = "/",
+                    {                        
                         First = new() { Aggregation = 0 },
+                        Operator = "/",
                         Second = new() { Aggregation = 1 },
                     }                    
                 },
@@ -1119,14 +1124,13 @@ namespace FlowerBI.Engine.Tests
                         from |Testing|!|Supplier| tbl00 
                         join |Testing|!|Invoice| tbl01 on |tbl01|!|VendorId| = |tbl00|!|Id| 
                         group by |tbl00|!|VendorName| 
-                    ) 
+                    )                     
                     select a0.Select0, 
                         a0.Value0 Value0 , 
                         a1.Value0 Value1 , 
                         a1.Value0 Value2 , 
-                        ([if]a0.Value0 is null[then]0[else]a0.Value0[endif] + [if]3 is null[then]0[else]3[endif]) Value3 ,
-                        [if][if]a1.Value0 is null[then]0[else]a1.Value0[endif] = 0[then]0[else][if]a0.Value0 is null[then]0[else]a0.Value0[endif] 
-                            / [float([if]a1.Value0 is null[then]0[else]a1.Value0[endif])][endif] Value4 
+                        ([if]a0.Value0 is null[then]42[else]a0.Value0[endif] + 3) Value3 , 
+                        [if]a1.Value0 = 0[then]0[else]a0.Value0 / [float(a1.Value0)][endif] Value4 
                     from Aggregation0 a0 
                     left join Aggregation1 a1 on a1.Select0 = a0.Select0 
                     order by {orderingExpected} asc 

--- a/server/dotnet/FlowerBI.Engine.Tests/QueryGenerationTests.cs
+++ b/server/dotnet/FlowerBI.Engine.Tests/QueryGenerationTests.cs
@@ -332,6 +332,56 @@ namespace FlowerBI.Engine.Tests
         }
 
         [Fact]
+        public void DoubleAggregationFullJoin()
+        {
+            var queryJson = new QueryJson
+            {
+                Select = new List<string> { "Vendor.VendorName" },
+                Aggregations = new List<AggregationJson>
+                {
+                    new AggregationJson
+                    {
+                        Column = "Invoice.Amount",
+                        Function = AggregationType.Sum
+                    },
+
+                    new AggregationJson
+                    {
+                        Column = "Invoice.Id",
+                        Function = AggregationType.Count
+                    }
+                },
+                Skip = 5,
+                Take = 10,
+                FullJoins = true,
+            };
+
+            var query = new Query(queryJson, Schema);
+            var filterParams = new DictionaryFilterParameters();
+            AssertSameSql(query.ToSql(Formatter, filterParams, Enumerable.Empty<Filter>()), @"
+                with Aggregation0 as (
+                    select |tbl00|!|VendorName| Select0, Sum(|tbl01|!|FancyAmount|) Value0
+                    from |Testing|!|Supplier| tbl00
+                    join |Testing|!|Invoice| tbl01 on |tbl01|!|VendorId| = |tbl00|!|Id|
+                    group by |tbl00|!|VendorName|
+                ) ,
+                Aggregation1 as (
+                    select |tbl00|!|VendorName| Select0, Count(|tbl01|!|Id|) Value0
+                    from |Testing|!|Supplier| tbl00
+                    join |Testing|!|Invoice| tbl01 on |tbl01|!|VendorId| = |tbl00|!|Id|
+                    group by |tbl00|!|VendorName|
+                )
+                select a0.Select0, a0.Value0 Value0 , a1.Value0 Value1
+                from Aggregation0 a0
+                full join Aggregation1 a1 on a1.Select0 = a0.Select0
+                order by a0.Value0 desc
+                skip:5 take:10
+            ");
+
+            filterParams.Names.Should().HaveCount(0);
+        }
+
+        [Fact]
         public void DoubleAggregationTotals()
         {
             var queryJson = new QueryJson
@@ -1071,11 +1121,12 @@ namespace FlowerBI.Engine.Tests
                         group by |tbl00|!|VendorName| 
                     ) 
                     select a0.Select0, 
-                            a0.Value0 Value0 , 
-                            a1.Value0 Value1 , 
-                            a1.Value0 Value2 , 
-                            (a0.Value0 + 3) Value3 , 
-                            [if]a1.Value0 = 0[then]0[else]a0.Value0 / [float(a1.Value0)][endif] Value4
+                        a0.Value0 Value0 , 
+                        a1.Value0 Value1 , 
+                        a1.Value0 Value2 , 
+                        ([if]a0.Value0 is null[then]0[else]a0.Value0[endif] + [if]3 is null[then]0[else]3[endif]) Value3 ,
+                        [if][if]a1.Value0 is null[then]0[else]a1.Value0[endif] = 0[then]0[else][if]a0.Value0 is null[then]0[else]a0.Value0[endif] 
+                            / [float([if]a1.Value0 is null[then]0[else]a1.Value0[endif])][endif] Value4 
                     from Aggregation0 a0 
                     left join Aggregation1 a1 on a1.Select0 = a0.Select0 
                     order by {orderingExpected} asc 

--- a/server/dotnet/FlowerBI.Engine/JsonModels/CalculationJson.cs
+++ b/server/dotnet/FlowerBI.Engine/JsonModels/CalculationJson.cs
@@ -42,9 +42,18 @@ public class CalculationJson
                 throw new InvalidOperationException($"Operator '{Operator}' not supported");
             }
 
+            string ValueOrZero(CalculationJson Node)
+            {
+                var expr = Node.ToSql(sql);
+                return sql.Conditional($"{expr} is null", "0", expr);
+            }
+
+            var firstExpr = ValueOrZero(First);
+            var secondExpr = ValueOrZero(Second);
+
             return Operator == "/"
-                ? sql.Conditional($"{Second.ToSql(sql)} = 0", "0", $"{First.ToSql(sql)} / {sql.CastToFloat(Second.ToSql(sql))}")
-                : $"({First.ToSql(sql)} {Operator} {Second.ToSql(sql)})";
+                ? sql.Conditional($"{secondExpr} = 0", "0", $"{firstExpr} / {sql.CastToFloat(secondExpr)}")
+                : $"({firstExpr} {Operator} {secondExpr})";
         }
 
         throw new InvalidOperationException("Calculation does not specify enough properties");

--- a/server/dotnet/FlowerBI.Engine/JsonModels/QueryJson.cs
+++ b/server/dotnet/FlowerBI.Engine/JsonModels/QueryJson.cs
@@ -23,6 +23,8 @@ namespace FlowerBI.Engine.JsonModels
         public string Comment { get; set; }
 
         public bool? AllowDuplicates { get; set; }
+
+        public bool? FullJoins { get; set; }
     }
 
     public class QueryRecordJson


### PR DESCRIPTION
Calculations always deal in numerical values. If there is no value for the category in one of the source aggregations, so it is `null`, the result of the arithmetic operation will also be `null`. So null-coalescing is needed. It can be added quite neatly as a new infix operator `??`.

An oversight since day one is using `left join` to connect aggregations. It should have been `full join`. Too late to make it the default now, sadly.