### PR TITLE
Full join coalesce fix

### DIFF
--- a/client/packages/flowerbi-dates/src/fillDates.test.ts
+++ b/client/packages/flowerbi-dates/src/fillDates.test.ts
@@ -2,64 +2,51 @@ import { fillDates, dateTypes, detectDateType } from "./fillDates";
 import moment from "moment";
 
 test("detects days", () => {
-    expect(detectDateType([
-        moment("2021-04-01"),
-        moment("2020-11-01"),
-        moment("2020-11-02"),
-        moment("2022-07-01"),
-    ])).toBe(dateTypes.days);
+    expect(detectDateType([moment("2021-04-01"), moment("2020-11-01"), moment("2020-11-02"), moment("2022-07-01")])).toBe(dateTypes.days);
 });
 
 test("detects months", () => {
-    expect(detectDateType([
-        moment("2021-04-01"),
-        moment("2020-11-01"),
-        moment("2022-07-01"),
-    ])).toBe(dateTypes.months);
+    expect(detectDateType([moment("2021-04-01"), moment("2020-11-01"), moment("2022-07-01")])).toBe(dateTypes.months);
 });
 
 test("detects quarters", () => {
-    expect(detectDateType([
-        moment("2021-04-01"),
-        moment("2020-10-01"),
-        moment("2022-07-01"),
-    ])).toBe(dateTypes.quarters);
+    expect(detectDateType([moment("2021-04-01"), moment("2020-10-01"), moment("2022-07-01")])).toBe(dateTypes.quarters);
 });
 
 test("detects years", () => {
-    expect(detectDateType([
-        moment("2021-01-01"),
-        moment("2020-01-01"),
-        moment("2022-01-01"),
-    ])).toBe(dateTypes.years);
+    expect(detectDateType([moment("2021-01-01"), moment("2020-01-01"), moment("2022-01-01")])).toBe(dateTypes.years);
 });
 
 test("handles empty list", () => {
-    expect(fillDates({
-        records: [], 
-        getDate: x => 0, 
-        fill: () => undefined
-    })).toStrictEqual([]);
+    expect(
+        fillDates({
+            records: [],
+            getDate: (x) => 0,
+            fill: () => undefined,
+        })
+    ).toStrictEqual([]);
 });
 
 test("leaves complete months alone", () => {
-    expect(fillDates({
-        records: [
-            { date: "2020-04-01", totalSales: 10 },
-            { date: "2020-05-01", totalSales: 4 },
-            { date: "2020-06-01", totalSales: 9 },            
-            { date: "2020-07-01", totalSales: 3 },
-        ],
-        getDate: rec => rec.date,
-        fill: (label, rec) => ({
-            label,
-            totalSales: 0,
-            ...rec
-        }),
-        min: "2020-04-12",
-        max: "2020-07-06"
-    })).toStrictEqual([
-        { label: "Apr 2020", date: "2020-04-01", totalSales: 10 },        
+    expect(
+        fillDates({
+            records: [
+                { date: "2020-04-01", totalSales: 10 },
+                { date: "2020-05-01", totalSales: 4 },
+                { date: "2020-06-01", totalSales: 9 },
+                { date: "2020-07-01", totalSales: 3 },
+            ],
+            getDate: (rec) => rec.date,
+            fill: (label, rec) => ({
+                label,
+                totalSales: 0,
+                ...rec,
+            }),
+            min: "2020-04-12",
+            max: "2020-07-06",
+        })
+    ).toStrictEqual([
+        { label: "Apr 2020", date: "2020-04-01", totalSales: 10 },
         { label: "May 2020", date: "2020-05-01", totalSales: 4 },
         { label: "Jun 2020", date: "2020-06-01", totalSales: 9 },
         { label: "Jul 2020", date: "2020-07-01", totalSales: 3 },
@@ -67,20 +54,22 @@ test("leaves complete months alone", () => {
 });
 
 test("fills in missing months", () => {
-    expect(fillDates({
-        records: [
-            { date: "2020-04-01", totalSales: 10 },
-            { date: "2020-06-01", totalSales: 4 },
-            { date: "2020-07-01", totalSales: 9 },            
-            { date: "2020-11-01", totalSales: 3 },
-        ],
-        getDate: rec => rec.date,
-        fill: (label, rec) => ({
-            label,
-            totalSales: 0,
-            ...rec
+    expect(
+        fillDates({
+            records: [
+                { date: "2020-04-01", totalSales: 10 },
+                { date: "2020-06-01", totalSales: 4 },
+                { date: "2020-07-01", totalSales: 9 },
+                { date: "2020-11-01", totalSales: 3 },
+            ],
+            getDate: (rec) => rec.date,
+            fill: (label, rec) => ({
+                label,
+                totalSales: 0,
+                ...rec,
+            }),
         })
-    })).toStrictEqual([
+    ).toStrictEqual([
         { label: "Apr 2020", date: "2020-04-01", totalSales: 10 },
         { label: "May 2020", totalSales: 0 },
         { label: "Jun 2020", date: "2020-06-01", totalSales: 4 },
@@ -93,22 +82,24 @@ test("fills in missing months", () => {
 });
 
 test("fills in missing months and min/max range", () => {
-    expect(fillDates({
-        records: [
-            { date: "2020-04-01", totalSales: 10 },
-            { date: "2020-06-01", totalSales: 4 },
-            { date: "2020-07-01", totalSales: 9 },            
-            { date: "2020-11-01", totalSales: 3 },
-        ],
-        getDate: rec => rec.date,
-        fill: (label, rec) => ({
-            label,
-            totalSales: 0,
-            ...rec
-        }),
-        min: "2020-02-15",
-        max: "2020-12-02"
-    })).toStrictEqual([
+    expect(
+        fillDates({
+            records: [
+                { date: "2020-04-01", totalSales: 10 },
+                { date: "2020-06-01", totalSales: 4 },
+                { date: "2020-07-01", totalSales: 9 },
+                { date: "2020-11-01", totalSales: 3 },
+            ],
+            getDate: (rec) => rec.date,
+            fill: (label, rec) => ({
+                label,
+                totalSales: 0,
+                ...rec,
+            }),
+            min: "2020-02-15",
+            max: "2020-12-02",
+        })
+    ).toStrictEqual([
         { label: "Feb 2020", totalSales: 0 },
         { label: "Mar 2020", totalSales: 0 },
         { label: "Apr 2020", date: "2020-04-01", totalSales: 10 },
@@ -124,23 +115,25 @@ test("fills in missing months and min/max range", () => {
 });
 
 test("leaves complete quarters alone", () => {
-    expect(fillDates({
-        records: [
-            { date: "2020-07-01", totalSales: 10 },
-            { date: "2020-10-01", totalSales: 4 },
-            { date: "2021-01-01", totalSales: 9 },            
-            { date: "2021-04-01", totalSales: 3 },
-        ],
-        getDate: rec => rec.date,
-        fill: (label, rec) => ({
-            label,
-            totalSales: 0,
-            ...rec
-        }),
-        min: "2020-07-12",
-        max: "2020-04-06"
-    })).toStrictEqual([
-        { label: "Jul-Sep 2020", date: "2020-07-01", totalSales: 10 },        
+    expect(
+        fillDates({
+            records: [
+                { date: "2020-07-01", totalSales: 10 },
+                { date: "2020-10-01", totalSales: 4 },
+                { date: "2021-01-01", totalSales: 9 },
+                { date: "2021-04-01", totalSales: 3 },
+            ],
+            getDate: (rec) => rec.date,
+            fill: (label, rec) => ({
+                label,
+                totalSales: 0,
+                ...rec,
+            }),
+            min: "2020-07-12",
+            max: "2020-04-06",
+        })
+    ).toStrictEqual([
+        { label: "Jul-Sep 2020", date: "2020-07-01", totalSales: 10 },
         { label: "Oct-Dec 2020", date: "2020-10-01", totalSales: 4 },
         { label: "Jan-Mar 2021", date: "2021-01-01", totalSales: 9 },
         { label: "Apr-Jun 2021", date: "2021-04-01", totalSales: 3 },
@@ -148,49 +141,53 @@ test("leaves complete quarters alone", () => {
 });
 
 test("fills in missing quarters", () => {
-    expect(fillDates({
-        records: [
-            { date: "2020-04-01", totalSales: 10 },
-            { date: "2020-10-01", totalSales: 4 },
-            { date: "2021-01-01", totalSales: 9 },            
-            { date: "2021-10-01", totalSales: 3 },
-        ],
-        type: dateTypes.quarters,
-        getDate: rec => rec.date,
-        fill: (label, rec) => ({
-            label,
-            totalSales: 0,
-            ...rec
+    expect(
+        fillDates({
+            records: [
+                { date: "2020-04-01", totalSales: 10 },
+                { date: "2020-10-01", totalSales: 4 },
+                { date: "2021-01-01", totalSales: 9 },
+                { date: "2021-10-01", totalSales: 3 },
+            ],
+            type: dateTypes.quarters,
+            getDate: (rec) => rec.date,
+            fill: (label, rec) => ({
+                label,
+                totalSales: 0,
+                ...rec,
+            }),
         })
-    })).toStrictEqual([
+    ).toStrictEqual([
         { label: "Apr-Jun 2020", date: "2020-04-01", totalSales: 10 },
         { label: "Jul-Sep 2020", totalSales: 0 },
         { label: "Oct-Dec 2020", date: "2020-10-01", totalSales: 4 },
         { label: "Jan-Mar 2021", date: "2021-01-01", totalSales: 9 },
         { label: "Apr-Jun 2021", totalSales: 0 },
-        { label: "Jul-Sep 2021", totalSales: 0 },        
+        { label: "Jul-Sep 2021", totalSales: 0 },
         { label: "Oct-Dec 2021", date: "2021-10-01", totalSales: 3 },
     ]);
 });
 
 test("fills in missing quarters and min/max range", () => {
-    expect(fillDates({
-        records: [
-            { date: "2020-04-01", totalSales: 10 },
-            { date: "2020-10-01", totalSales: 4 },
-            { date: "2021-01-01", totalSales: 9 },            
-            { date: "2021-10-01", totalSales: 3 },
-        ],
-        type: dateTypes.quarters,
-        getDate: rec => rec.date,
-        fill: (label, rec) => ({
-            label,
-            totalSales: 0,
-            ...rec
-        }),
-        min: "2019-10-10",
-        max: "2022-01-06"
-    })).toStrictEqual([
+    expect(
+        fillDates({
+            records: [
+                { date: "2020-04-01", totalSales: 10 },
+                { date: "2020-10-01", totalSales: 4 },
+                { date: "2021-01-01", totalSales: 9 },
+                { date: "2021-10-01", totalSales: 3 },
+            ],
+            type: dateTypes.quarters,
+            getDate: (rec) => rec.date,
+            fill: (label, rec) => ({
+                label,
+                totalSales: 0,
+                ...rec,
+            }),
+            min: "2019-10-10",
+            max: "2022-01-06",
+        })
+    ).toStrictEqual([
         { label: "Oct-Dec 2019", totalSales: 0 },
         { label: "Jan-Mar 2020", totalSales: 0 },
         { label: "Apr-Jun 2020", date: "2020-04-01", totalSales: 10 },
@@ -205,21 +202,23 @@ test("fills in missing quarters and min/max range", () => {
 });
 
 test("explicit type overrides detection", () => {
-    expect(fillDates({
-        records: [
-            { date: "2020-07-01", totalSales: 10 },
-            { date: "2020-10-01", totalSales: 4 },
-            { date: "2021-01-01", totalSales: 9 },            
-            { date: "2021-04-01", totalSales: 3 },
-        ],
-        getDate: rec => rec.date,
-        fill: (label, rec) => ({
-            label,
-            totalSales: 0,
-            ...rec
-        }),
-        type: dateTypes.months
-    })).toStrictEqual([
+    expect(
+        fillDates({
+            records: [
+                { date: "2020-07-01", totalSales: 10 },
+                { date: "2020-10-01", totalSales: 4 },
+                { date: "2021-01-01", totalSales: 9 },
+                { date: "2021-04-01", totalSales: 3 },
+            ],
+            getDate: (rec) => rec.date,
+            fill: (label, rec) => ({
+                label,
+                totalSales: 0,
+                ...rec,
+            }),
+            type: dateTypes.months,
+        })
+    ).toStrictEqual([
         { label: "Jul 2020", date: "2020-07-01", totalSales: 10 },
         { label: "Aug 2020", totalSales: 0 },
         { label: "Sep 2020", totalSales: 0 },
@@ -230,5 +229,32 @@ test("explicit type overrides detection", () => {
         { label: "Feb 2021", totalSales: 0 },
         { label: "Mar 2021", totalSales: 0 },
         { label: "Apr 2021", date: "2021-04-01", totalSales: 3 },
+    ]);
+});
+
+test("skips any rogue null dates", () => {
+    expect(
+        fillDates({
+            records: [
+                { date: null, totalSales: 10 },
+                { date: "2020-06-01", totalSales: 4 },
+                { date: "2020-07-01", totalSales: 9 },
+                { date: "2020-11-01", totalSales: 3 },
+            ],
+            getDate: (rec) => rec.date!,
+            fill: (label, rec) => ({
+                label,
+                totalSales: 0,
+                ...rec,
+            }),
+            type: dateTypes.months,
+        })
+    ).toStrictEqual([
+        { label: "Jun 2020", date: "2020-06-01", totalSales: 4 },
+        { label: "Jul 2020", date: "2020-07-01", totalSales: 9 },
+        { label: "Aug 2020", totalSales: 0 },
+        { label: "Sep 2020", totalSales: 0 },
+        { label: "Oct 2020", totalSales: 0 },
+        { label: "Nov 2020", date: "2020-11-01", totalSales: 3 },
     ]);
 });

--- a/client/packages/flowerbi/src/QueryJson.ts
+++ b/client/packages/flowerbi/src/QueryJson.ts
@@ -112,4 +112,8 @@ export interface QueryJson {
      * See {@link Query.allowDuplicates}.
      */
     allowDuplicates?: boolean;
+    /**
+     * See {@link Query.fullJoins}.
+     */
+    fullJoins?: boolean;
 }

--- a/client/packages/flowerbi/src/executeQuery.test.ts
+++ b/client/packages/flowerbi/src/executeQuery.test.ts
@@ -38,6 +38,7 @@ test("jsonifies mixed columns", () => {
         totals: false,
         allowDuplicates: undefined,
         comment: undefined,
+        fullJoins: undefined,
     });
 });
 
@@ -59,6 +60,7 @@ test("jsonifies select", () => {
         totals: false,
         allowDuplicates: undefined,
         comment: undefined,
+        fullJoins: undefined,
     });
 });
 
@@ -83,6 +85,7 @@ test("jsonifies params", () => {
         totals: true,
         allowDuplicates: true,
         comment: "a comment",
+        fullJoins: undefined,
     });
 });
 
@@ -123,6 +126,7 @@ test("jsonifies filters", () => {
         totals: false,
         allowDuplicates: undefined,
         comment: undefined,
+        fullJoins: undefined,
     });
 });
 
@@ -148,6 +152,7 @@ test("jsonifies orderBy", () => {
         totals: false,
         allowDuplicates: undefined,
         comment: undefined,
+        fullJoins: undefined,
     });
 });
 
@@ -226,6 +231,7 @@ test("jsonifies calculations and ordering by keys", () => {
         totals: false,
         allowDuplicates: undefined,
         comment: undefined,
+        fullJoins: undefined,
     });
 });
 
@@ -251,6 +257,7 @@ test("passes through JSON orderBy", () => {
         totals: false,
         allowDuplicates: undefined,
         comment: undefined,
+        fullJoins: undefined,
     });
 });
 

--- a/client/packages/flowerbi/src/executeQuery.ts
+++ b/client/packages/flowerbi/src/executeQuery.ts
@@ -128,7 +128,7 @@ function jsonifyOrdering<S extends QuerySelect, C extends QueryCalculations<S>>(
  * @param query
  */
 export function jsonifyQuery<S extends QuerySelect, C extends QueryCalculations<S>>(query: Query<S, C>): QueryJson {
-    const { select, filters, calculations, orderBy, totals, take, skip, comment, allowDuplicates } = query;
+    const { select, filters, calculations, orderBy, totals, take, skip, comment, allowDuplicates, fullJoins } = query;
 
     const columnProps = getColumnPropsOnly(select);
     const aggregationProps = getAggregatePropsOnly(select);
@@ -145,6 +145,7 @@ export function jsonifyQuery<S extends QuerySelect, C extends QueryCalculations<
         take: take ?? 100,
         comment,
         allowDuplicates,
+        fullJoins,
     };
 }
 

--- a/client/packages/flowerbi/src/queryModel.ts
+++ b/client/packages/flowerbi/src/queryModel.ts
@@ -198,4 +198,11 @@ export interface Query<S extends QuerySelect, C extends QueryCalculations<S>> {
      * are known to be impossible.
      */
     allowDuplicates?: boolean;
+    /**
+     * If false, the number of rows returned will be limited by the first
+     * aggregation. This is probably not desirable and it would be better if
+     * this option defaulted to true, but it defaults to false for absolute
+     * backward compatibility.
+     */
+    fullJoins?: boolean;
 }

--- a/server/dotnet/FlowerBI.Engine/QueryGeneration/Query.cs
+++ b/server/dotnet/FlowerBI.Engine/QueryGeneration/Query.cs
@@ -60,9 +60,22 @@ with {{#each Aggregations}}
 
 select
 
-{{#each Select}}
-    a0.Select{{@index}},
-{{/each}}
+{{#if fullJoins}}
+    {{#each Select}}
+        coalesce(
+            {{#each ../Aggregations}}
+                a{{@index}}.Select{{@../index}}
+                {{#unless @last}},{{/unless}}
+            {{/each}}
+        ) Select{{@index}},
+    {{/each}}
+{{/if}}
+
+{{#unless fullJoins}}
+    {{#each Select}}
+        a0.Select{{@index}},
+    {{/each}}
+{{/unless}}
 
 {{#each Calculations}}
     {{{this}}} Value{{@index}}
@@ -118,7 +131,8 @@ from Aggregation0 a0
                     .Concat(Calculations.Select(x => x.ToSql(sql))),
                 Select = select,
                 orderBy = totals ? null : ordering,
-                joinType = FullJoins ? "full" : "left" 
+                joinType = FullJoins ? "full" : "left",
+                fullJoins = FullJoins ? "full" : null,
             });
         }
 


### PR DESCRIPTION
Previously the generated SQL could assume that the first aggregation would always be populated. But when using the `fullJoins` option, any aggregation may be missing and thus have a null value. We expect at least one selected column to be non-null (and we ensure that if any two are non-null then they will be equal), so we need to use the `coalesce` function to take the first non-null value for each selected column.

This problem revealed a second one: `fillDates` helper did not cope very well with these null values. Now it ignores them.

The `fullJoins` setting is also added to the client types (this was already released in 3.10.1 but I didn't PR it!)