### PR TITLE
Full joins better

### DIFF
--- a/server/dotnet/FlowerBI.Engine.Tests/QueryGenerationTests.cs
+++ b/server/dotnet/FlowerBI.Engine.Tests/QueryGenerationTests.cs
@@ -236,7 +236,7 @@ namespace FlowerBI.Engine.Tests
                 Totals = true,
                 Skip = 5,
                 Take = 10,
-                FullJoins = true,
+                FullJoins = fullJoins,
             };
 
             var query = new Query(queryJson, Schema);
@@ -381,8 +381,11 @@ namespace FlowerBI.Engine.Tests
                     group by |tbl00|!|VendorName|
                 ) ,
                 UnionedValues as ( 
-                    select Select0 , Value0 as Value0 , null as Value1 union all 
+                    select Select0 , Value0 as Value0 , null as Value1 
+                    from Aggregation0
+                    union all 
                     select Select0 , null as Value0 , Value0 as Value1 
+                    from Aggregation1
                 ),
                 CombinedValues as ( 
                     select Select0, max(Value0) as Value0 , max(Value1) as Value1 
@@ -1275,8 +1278,12 @@ namespace FlowerBI.Engine.Tests
                         group by |tbl00|!|VendorName| 
                     ) , 
                     UnionedValues as ( 
-                        select Select0 , Value0 as Value0 , null as Value1 union all 
-                        select Select0 , null as Value0 , Value0 as Value1 ), 
+                        select Select0 , Value0 as Value0 , null as Value1 
+                        from Aggregation0
+                        union all 
+                        select Select0 , null as Value0 , Value0 as Value1
+                        from Aggregation1
+                    ), 
                     CombinedValues as ( 
                         select Select0, max(Value0) as Value0 , max(Value1) as Value1 
                         from UnionedValues 
@@ -1367,8 +1374,12 @@ namespace FlowerBI.Engine.Tests
                     group by |tbl00|!|VendorName| , |tbl00|!|DepartmentId|
                 ) , 
                 UnionedValues as ( 
-                    select Select0 , Select1 , Value0 as Value0 , null as Value1 union all 
-                    select Select0 , Select1 , null as Value0 , Value0 as Value1 ), 
+                    select Select0 , Select1 , Value0 as Value0 , null as Value1 
+                    from Aggregation0
+                    union all 
+                    select Select0 , Select1 , null as Value0 , Value0 as Value1 
+                    from Aggregation1
+                ), 
                 CombinedValues as ( 
                     select Select0, Select1, max(Value0) as Value0 , max(Value1) as Value1 
                     from UnionedValues 

--- a/server/dotnet/FlowerBI.Engine/JsonModels/CalculationJson.cs
+++ b/server/dotnet/FlowerBI.Engine/JsonModels/CalculationJson.cs
@@ -19,7 +19,7 @@ public class CalculationJson
     private static readonly ISet<string> _allowedOperators 
         = new[] { "+", "-", "*", "/", "??" }.ToHashSet();
 
-    public string ToSql(ISqlFormatter sql)
+    public string ToSql(ISqlFormatter sql, Func<int, string> fetchAggValue)
     {
         if (Value != null)
         {
@@ -30,7 +30,7 @@ public class CalculationJson
         if (Aggregation != null)
         {
             RequireNulls(Value, First, Second, Operator);
-            return $"a{Aggregation}.Value0";
+            return fetchAggValue(Aggregation.Value);
         }
 
         if (First != null && Second != null && Operator != null)
@@ -42,8 +42,8 @@ public class CalculationJson
                 throw new InvalidOperationException($"Operator '{Operator}' not supported");
             }
 
-            var firstExpr = First.ToSql(sql);
-            var secondExpr = Second.ToSql(sql);
+            var firstExpr = First.ToSql(sql, fetchAggValue);
+            var secondExpr = Second.ToSql(sql, fetchAggValue);
 
             return Operator == "/"
                 ? sql.Conditional($"{secondExpr} = 0", "0", $"{firstExpr} / {sql.CastToFloat(secondExpr)}")

--- a/server/dotnet/FlowerBI.Engine/QueryGeneration/Query.cs
+++ b/server/dotnet/FlowerBI.Engine/QueryGeneration/Query.cs
@@ -66,10 +66,11 @@ with {{#each Aggregations}}
 
     {{#each unionedValues}}
         select 
-        {{#each this}}
+        {{#each Columns}}
             {{#unless @first}}, {{/unless}}
             {{this}}
         {{/each}}
+        from {{Source}}
         {{#unless @last}}union all{{/unless}}
     {{/each}}
     ),
@@ -165,10 +166,14 @@ select
                 Select = select,
                 orderBy = totals ? null : ordering,
                 fullJoins,
-                unionedValues = Aggregations.Select((_, aRow) => 
-                    select.Select((_, s) => $"Select{s}")
-                          .Concat(Aggregations.Select((_, aCol) => (Source: aRow == aCol ? "Value0" : "null", Target: $"Value{aCol}"))
-                                              .Select(x => $"{x.Source} as {x.Target}")))
+                unionedValues = Aggregations.Select((_, aRow) => new
+                {
+                    Source = $"Aggregation{aRow}",
+                    Columns = select.Select((_, s) => $"Select{s}")
+                                    .Concat(Aggregations
+                                            .Select((_, aCol) => (Source: aRow == aCol ? "Value0" : "null", Target: $"Value{aCol}"))
+                                            .Select(x => $"{x.Source} as {x.Target}"))
+                })
             });
         }
 


### PR DESCRIPTION
The recent enhancement adding support for `fullJoins` had a flaw in its implementation, which seems impossible to solve by using SQL's `full join` and therefore (ironically) the `fullJoins` property will have to be implemented without using that SQL feature.

If a query has multiple aggregations and at least one non-aggregated select, we declare a separate CTE for each aggregation and then merge the results. Each aggregation CTE looks like:

```
with Aggregation0 as (
    select 
        someColumn as Select0, 
        otherColumn as Select1, 
        sum(whatever)` as Value0,
    from /* tables */
),
Aggregation 1 as ...
```

So they each output `Select0, Select1... SelectN` and a single aggregated value with the name `Value0`.

We want to merge these into a table with one row for every distinct combination of the `Select1...N` columns, and with further columns `Value0`, `Value1` which are the renamed `Value0` from each CTE.

To achieve this, first we `union` all the results into a common structure with the correct names for the `ValueN` columns, filling in the gaps with `null`:

```sql 
UnionedValues as ( 
    select Select0, Select1, Value0 as Value0, null as Value1 
    from Aggregation0
    union all
    select Select0, Select1, null as Value0, Value0 as Value1 
    from Aggregation1
),
```

Then we can ensure a single row per distinct `Select1...N` combination by grouping:

```
CombinedValues as ( 
    select Select0, Select1, max(Value0) as Value0 , max(Value1) as Value1 
    from UnionedValues 
    group by Select0, Select1
)
```
 
Note the use of `max` to pick one `ValueN` is arbitrary, as by design there can only be one non-null value in each group.