### PR TITLE
Handlebars turning `&` into` &amp;`

### DIFF
--- a/server/dotnet/FlowerBI.Engine/QueryGeneration/Query.cs
+++ b/server/dotnet/FlowerBI.Engine/QueryGeneration/Query.cs
@@ -40,7 +40,7 @@ public class Query(QueryJson json, Schema schema)
     private const string _templateMain = """
         select
             {{#each selects}}
-            {{this}}{{#unless @last}}, {{/unless}}
+            {{{this}}}{{#unless @last}}, {{/unless}}
             {{/each}}
         {{joins}}
         {{#if filters}}


### PR DESCRIPTION
Have to use triple braces to stop this default behaviour. Maybe rip out handlebars? Not sure it's clarifying much anyway.