### PR TITLE
Stronger validation of filters

### DIFF
--- a/server/dotnet/FlowerBI.Engine.Tests/FilterParametersTests.cs
+++ b/server/dotnet/FlowerBI.Engine.Tests/FilterParametersTests.cs
@@ -130,4 +130,17 @@ public class FilterParametersTests
         a.Should().Throw<InvalidOperationException>()
                   .WithMessage("Filter JSON contains empty array");
     }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void DapperFilterParameters_ObjectWithEmptyArrayProperty_CaughtEarly(bool newtonSoft)
+    {   
+        var p = new DapperFilterParameters();
+
+        Func<string> a = () => p[MakeFilter(new { x = Array.Empty<double>() }, newtonSoft)];
+
+        a.Should().Throw<InvalidOperationException>()
+                  .WithMessage("Unsupported filter value");
+    }
 }

--- a/server/dotnet/FlowerBI.Engine/QueryGeneration/Filter.cs
+++ b/server/dotnet/FlowerBI.Engine/QueryGeneration/Filter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
@@ -8,73 +9,115 @@ using Microsoft.Win32.SafeHandles;
 
 namespace FlowerBI
 {
-    public class Filter
+    public class Filter(LabelledColumn column, string op, object val, object constant)
     {
-        public LabelledColumn Column { get; }
+        public LabelledColumn Column { get; } = column;
 
-        public string Operator { get; }
+        public string Operator { get; } = CheckOperator(op);
 
-        public object Value { get; }
+        public object Value { get; } = val;
 
-        public object Constant { get; }
+        public object Constant { get; } = constant;
 
-        public static IList<Filter> Load(IEnumerable<FilterJson> filters, Schema schema)
-            => filters?.Select(x => new Filter(x, schema)).ToList() ?? [];
-
-        public Filter(LabelledColumn column, string op, object val, object constant)
-        {
-            Column = column;
-            Operator = CheckOperator(op);
-            Value = val;
-            Constant = constant;
-        }
+        public static IList<Filter> Load(IEnumerable<FilterJson> filters, Schema schema) =>
+            filters?.Select(x => new Filter(x, schema)).ToList() ?? [];
 
         public Filter(IColumn column, string op, object val, object constant)
-            : this(new LabelledColumn(null, column), op, val, constant) {}
+            : this(new LabelledColumn(null, column), op, val, constant) { }
 
         public Filter(FilterJson json, Schema schema)
-            : this(schema.GetColumn(json.Column), json.Operator, UnpackValue(json.Value), UnpackValue(json.Constant)) { }
+            : this(
+                schema.GetColumn(json.Column),
+                json.Operator,
+                UnpackAndValidateValue(json.Value),
+                UnpackAndValidateValue(json.Constant)
+            ) { }
 
-        private static void ValidateArraySize(int size)
+        private static readonly HashSet<Type> _basicValueTypes = [
+            typeof(bool),
+            typeof(byte),
+            typeof(short),
+            typeof(ushort),
+            typeof(int),
+            typeof(uint),
+            typeof(long),
+            typeof(ulong),
+            typeof(float),
+            typeof(double),
+            typeof(string),
+            typeof(DateTime)
+        ];
+
+        private static void ValidateBasicType(object value)
         {
-            // We don't silently strip out filters with empty lists of required values so 
-            // that filtering can be used for security controls (denying access to data).
-            //
-            // This has always been the case, but now it produces a descriptive error 
-            // instead of of a SQL syntax error.
-            if (size == 0)
+            var type = value.GetType();
+            if (!_basicValueTypes.Contains(type))
             {
-                throw new InvalidOperationException("Filter JSON contains empty array");
+                throw new InvalidOperationException($"Unsupported filter value");
             }
+        }
+
+        private static object UnpackAndValidateValue(object json)
+        {
+            var unpacked = UnpackValue(json);
+            if (unpacked is null) return null;
+            if (_basicValueTypes.Contains(unpacked.GetType())) return unpacked;
+
+            if (unpacked is IEnumerable enumerable)
+            {
+                var empty = true;
+
+                foreach (var item in enumerable)
+                {
+                    ValidateBasicType(item);
+                    empty = false;
+                }
+
+                if (empty)
+                {
+                    // We don't silently strip out filters with empty lists of required values so
+                    // that filtering can be used for security controls (denying access to data).
+                    //
+                    // This has always been the case, but now it produces a descriptive error
+                    // instead of a SQL syntax error.
+                    throw new InvalidOperationException("Filter JSON contains empty array");
+                }
+
+                return unpacked;
+            }
+            
+            ValidateBasicType(unpacked);
+            return unpacked;
         }
 
         private static object UnpackValue(object json)
         {
             if (json is JsonElement e)
             {
-                if (e.ValueKind == JsonValueKind.Array)
-                {
-                    ValidateArraySize(e.GetArrayLength());
-                }
-
-                return e.ValueKind == JsonValueKind.False ? false :
-                    e.ValueKind == JsonValueKind.True ? true :
-                    e.ValueKind == JsonValueKind.Number ? e.GetDouble() :
-                    e.ValueKind == JsonValueKind.String ? (DateTime.TryParse(e.GetString(), out var dt) ? dt : (object)e.GetString()) :
-                    e.ValueKind == JsonValueKind.Array ? 
-                        e.EnumerateArray().Select(item =>
-                            item.ValueKind == JsonValueKind.False ? false :
-                            item.ValueKind == JsonValueKind.True ? true :
-                            item.ValueKind == JsonValueKind.Number ? (object)item.GetDouble() :
-                            item.ValueKind == JsonValueKind.String ? item.GetString()
-                            : throw new InvalidOperationException("Unsupported filter value format in list item")).ToList()
-                    : throw new InvalidOperationException("Unsupported filter value format");
+                return e.ValueKind == JsonValueKind.False ? false
+                    : e.ValueKind == JsonValueKind.True ? true
+                    : e.ValueKind == JsonValueKind.Number ? e.GetDouble()
+                    : e.ValueKind == JsonValueKind.String
+                        ? (
+                            DateTime.TryParse(e.GetString(), out var dt)
+                                ? dt
+                                : e.GetString()
+                        )
+                    : e.ValueKind == JsonValueKind.Array
+                        ? e.EnumerateArray()
+                            .Select(item =>
+                                item.ValueKind == JsonValueKind.False ? false
+                                : item.ValueKind == JsonValueKind.True ? true
+                                : item.ValueKind == JsonValueKind.Number ? (object)item.GetDouble()
+                                : item.ValueKind == JsonValueKind.String ? item.GetString()
+                                : new object()
+                            )
+                            .ToList()
+                    : new object();
             }
 
             if (json is IEnumerable<object> l)
             {
-                ValidateArraySize(l.Count());
-
                 return l.Select(UnpackNewtonsoft).ToList();
             }
 
@@ -90,7 +133,12 @@ namespace FlowerBI
             }
 
             var type = val.GetType();
-            if (type.IsPrimitive || type == typeof(string) || type == typeof(DateTime) || type == typeof(decimal))
+            if (
+                type.IsPrimitive
+                || type == typeof(string)
+                || type == typeof(DateTime)
+                || type == typeof(decimal)
+            )
             {
                 return val;
             }
@@ -102,7 +150,17 @@ namespace FlowerBI
 
         private static readonly HashSet<string> _allowedOperators = new HashSet<string>
         {
-            "=", "<>", "!=", ">", "<", ">=", "<=", "IN", "NOT IN", "BITS IN", "LIKE"
+            "=",
+            "<>",
+            "!=",
+            ">",
+            "<",
+            ">=",
+            "<=",
+            "IN",
+            "NOT IN",
+            "BITS IN",
+            "LIKE",
         };
 
         private static string CheckOperator(string op)


### PR DESCRIPTION
Safer to whitelist allowed basic filter value types and then verify that the unpacked value is either null, a basic value or an enumerable of basic values. This check is done at the end of unpacking, exactly the same way for `Newtonsoft` or `System.Text.Json`.