### PR TITLE
Full joins (again)

### DIFF
--- a/server/dotnet/FlowerBI.Engine.Tests/ExecutionTests.cs
+++ b/server/dotnet/FlowerBI.Engine.Tests/ExecutionTests.cs
@@ -1132,4 +1132,43 @@ public abstract class ExecutionTests
 
         records.Select(x => x.Item2).Should().BeInDescendingOrder();
     }
+
+    [Fact]
+    public void FullJoins()
+    {
+        var queryJson = new QueryJson
+        {
+            FullJoins = true,
+            Select = ["Vendor.VendorName"],
+            Aggregations = [new() { Column = "Invoice.Amount", Function = AggregationType.Sum }],
+        };
+
+        var results = ExecuteQuery(queryJson);
+        var records = results.Records.Select(x => (x.Selected[0], Round(x.Aggregated[0])));
+
+        records
+            .Should()
+            .BeEquivalentTo(
+                [
+                    ("[United Cheese]", 406.84m),
+                    ("[Handbags-a-Plenty]", 252.48m),
+                    ("[Steve Makes Sandwiches]", 176.24m),
+                    ("[Manchesterford Supplies Inc]", 164.36m),
+                    ("[Disgusting Ltd]", 156.14m),
+                    ("[Statues While You Wait]", 156.24m),
+                    ("[Tiles Tiles Tiles]", 106.24m),
+                    ("[Uranium 4 Less]", 88.12m),
+                    ("[Awnings-R-Us]", 88.12m),
+                    ("[Pleasant Plc]", 88.12m),
+                    ("[Mats and More]", 76.24m),
+                    ("[Party Hats 4 U]", 58.12m),
+                    ("[Stationary Stationery]", 28.12m),
+                    ("[Acme Ltd]", default(decimal?)), // Included due to full join
+                ]
+            );
+
+        records.Select(x => x.Item2).Should().BeInDescendingOrder();
+
+        results.Totals.Should().BeNull();
+    }
 }

--- a/server/dotnet/FlowerBI.Engine/JsonModels/QueryJson.cs
+++ b/server/dotnet/FlowerBI.Engine/JsonModels/QueryJson.cs
@@ -23,6 +23,8 @@ public class QueryJson
     public string Comment { get; set; }
 
     public bool? AllowDuplicates { get; set; }
+
+    public bool? FullJoins { get; set; }
 }
 
 public class QueryRecordJson

--- a/server/dotnet/FlowerBI.Engine/QueryGeneration/Joins.cs
+++ b/server/dotnet/FlowerBI.Engine/QueryGeneration/Joins.cs
@@ -172,9 +172,12 @@ public class Joins
         }
     }
 
-    public string ToSql(ISqlFormatter sql) => ToSqlAndTables(sql).Sql;
+    public string ToSql(ISqlFormatter sql, bool fullJoins) => ToSqlAndTables(sql, fullJoins).Sql;
 
-    public (string Sql, IEnumerable<LabelledTable> Tables) ToSqlAndTables(ISqlFormatter sql)
+    public (string Sql, IEnumerable<LabelledTable> Tables) ToSqlAndTables(
+        ISqlFormatter sql,
+        bool fullJoins
+    )
     {
         var needed = Aliases.OrderBy(x => x.Value).Select(x => x.Key).ToList();
 
@@ -257,6 +260,8 @@ public class Joins
 
         var joinedSoFar = new HashSet<LabelledTable> { root };
 
+        var joinType = fullJoins ? "full join" : "join";
+
         foreach (var table in reachable.Where(x => x != root))
         {
             var availableArrows = tables.GetLabelledArrows(table);
@@ -282,7 +287,7 @@ public class Joins
             }
 
             output.Add(
-                $"join {table.Value.ToSql(sql)} {GetAlias(table)} on {string.Join(" and ", criteria)}"
+                $"{joinType} {table.Value.ToSql(sql)} {GetAlias(table)} on {string.Join(" and ", criteria)}"
             );
 
             joinedSoFar.Add(table);

--- a/server/dotnet/FlowerBI.Engine/QueryGeneration/Query.cs
+++ b/server/dotnet/FlowerBI.Engine/QueryGeneration/Query.cs
@@ -40,6 +40,8 @@ public class Query(QueryJson json, Schema schema)
 
     public int CommandTimeoutSeconds { get; } = 30;
 
+    public bool FullJoins { get; } = json.FullJoins ?? false;
+
     private const string _templateMain = """
         select
             {{#each selects}}
@@ -224,7 +226,7 @@ public class Query(QueryJson json, Schema schema)
         var template =
             calculations.Count == 0 ? _templateWithoutCalculations : _templateWithCalculations;
 
-        var (joinSql, joinedTables) = joins.ToSqlAndTables(sql);
+        var (joinSql, joinedTables) = joins.ToSqlAndTables(sql, FullJoins);
 
         var sqlFromTemplate = template(
             new


### PR DESCRIPTION
There are situations where `full join` is appropriate, though this needs to be under the discretion of the user. As `full join` is commutative and associative (like `inner join`) it still behaves predictably with the tables specified in any order, so it can just be switched on as required.